### PR TITLE
Retry fetching model registry on failure

### DIFF
--- a/src/background/WASMTranslationHelper.js
+++ b/src/background/WASMTranslationHelper.js
@@ -41,7 +41,7 @@ class BergamotBacking extends TranslatorBacking {
      *  }>>}
      */
     async loadModelRegistery() {
-        const response = await fetch('https://translatelocally.com/models.json');
+        const response = await fetch('https://translatelocally.com/models.json', {cache: 'default'});
         let {models} = await response.json();
         let serial = 0;
 

--- a/src/background/WASMTranslationHelper.js
+++ b/src/background/WASMTranslationHelper.js
@@ -26,9 +26,8 @@ class BergamotBacking extends TranslatorBacking {
     }
 
     /**
-     * Loads the model registry. Uses the registry shipped with this extension,
-     * but formatted a bit easier to use, and future-proofed to be swapped out
-     * with a TranslateLocally type registry.
+     * Fetches the model registry, and translates it from TranslateLocally
+     * format to the one used by the bergamot-translator npm library.
      * @returns {Promise<List<{
      *  from: String,
      *  to: String,
@@ -40,7 +39,7 @@ class BergamotBacking extends TranslatorBacking {
      *    checksum: String
      *  }>>}
      */
-    async loadModelRegistery() {
+    async fetchModelRegistry() {
         const response = await fetch('https://translatelocally.com/models.json', {cache: 'default'});
         let {models} = await response.json();
         let serial = 0;
@@ -91,6 +90,47 @@ class BergamotBacking extends TranslatorBacking {
         });
 
         return Array.from(entries);
+    }
+
+    /**
+     * Hook into TranslatorBacking that returns a fake promise that will reload
+     * if the previous fetch failed, but hide the error. This is to work around
+     * a scenario where Firefox is started without internet connection and
+     * loading the model registry fails. We'll want to re-attempt to fetch the
+     * registry later, as opposed to cause the extension to fail to load.
+     * See also https://github.com/jelmervdl/translatelocally-web-ext/issues/61
+     * @returns {Promise<List<{
+     *  from: String,
+     *  to: String,
+     *  model: {
+     *    id: Number,
+     *    local: Boolean,
+     *    shortName: String,
+     *    url: String,
+     *    checksum: String
+     *  }>>}
+     */
+    loadModelRegistery() {
+        let lastFetch = null;
+        
+        const tryFetch = () => {
+            lastFetch = new Promise(async (accept, reject) => {
+                try {
+                    accept(await this.fetchModelRegistry());
+                } catch (e) {
+                    accept([]); // for now to not cause a scene
+                    lastFetch = null; // but retry next time we're asked
+                }
+            });
+        };
+
+        return new class {
+            then(...args) {
+                if (!lastFetch)
+                    tryFetch();
+                lastFetch.then(...args)
+            }
+        }
     }
 
     /**

--- a/webpack.config.mjs
+++ b/webpack.config.mjs
@@ -52,6 +52,14 @@ const module = {
   ]
 };
 
+const distPath = new URL("./extension", import.meta.url).pathname;
+
+// Set to `false` if you want to use a consistent profile
+const firefoxOptions = true ? {} : {
+  firefoxProfile: 'translatelocally-web-ext',
+  keepProfileChanges: true
+};
+
 export default {
   module,
   mode: 'development',
@@ -63,7 +71,7 @@ export default {
     'popup': './src/popup/popup.js'
   },
   output: {
-    path: new URL("./extension", import.meta.url).pathname,
+    path: distPath,
     publicPath: '',
     chunkFormat: 'array-push',
     assetModuleFilename: '[name][ext]',
@@ -123,8 +131,9 @@ export default {
       'typeof self': JSON.stringify('object')
     }),
     new WebExtPlugin({
-      sourceDir: '../../extension',
+      sourceDir: distPath,
       firefox: 'nightly',
+      ...firefoxOptions
     })
   ],
   experiments: {


### PR DESCRIPTION
This works around issues that happen when there's no active internet connection when the extension is loaded.

Fixes #61 .